### PR TITLE
Update balloon detection launch files for jetson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ uv.lock
 
 # Sample videos are not tracked.
 pooh/*.mp4
+yolov8x-worldv2.pt

--- a/README.md
+++ b/README.md
@@ -77,6 +77,23 @@ does not need to match the ROS-distro's Python ABI. This is what makes the
 uv path usable on Ubuntu 20.04 / ROS noetic, where the stock
 `cv_bridge_boost.so` is locked to Python 3.8.
 
+### Jetson / reComputer note: rebuild torchvision with CUDA
+
+On Jetson / reComputer, the `torchvision` installed by the package
+virtualenv may not match the Jetson CUDA-enabled PyTorch environment.
+If importing or running the detector fails around `torchvision`, rebuild
+`torchvision` inside the package virtualenv with CUDA enabled.
+
+```bash
+source ~/ros/balloon-detection/devel/.private/balloon_detection/share/balloon_detection/venv/bin/activate
+
+pip uninstall -y torchvision
+
+FORCE_CUDA=1 TORCH_CUDA_ARCH_LIST="8.7" BUILD_VERSION=0.13.0 MAX_JOBS=4 \
+pip install --no-cache-dir --no-build-isolation \
+"git+https://github.com/pytorch/vision.git@v0.13.0#egg=torchvision"
+```
+
 ## Run
 
 ```bash

--- a/launch/detect_events.launch
+++ b/launch/detect_events.launch
@@ -11,7 +11,7 @@
   <arg name="image_topic" default="image"
        doc="Input sensor_msgs/Image topic (remapped onto the node's 'image')."/>
   <arg name="model" default="yolov8x-worldv2.pt"/>
-  <arg name="device" default="cpu"/>
+  <arg name="device" default="cuda"/>
   <arg name="balloon_classes" default="balloon,red balloon"
        doc="Comma-separated YOLO-World prompts treated as the balloon class."/>
   <arg name="teddy_classes" default="teddy bear,stuffed animal,Winnie the Pooh plush"

--- a/launch/video.launch
+++ b/launch/video.launch
@@ -14,7 +14,7 @@
        doc="Rate at which video_stream_opencv publishes frames."/>
   <arg name="loop" default="false"/>
   <arg name="visualize" default="true"/>
-  <arg name="device" default="cpu"/>
+  <arg name="device" default="cuda"/>
   <arg name="model" default="yolov8x-worldv2.pt"/>
   <arg name="balloon_classes" default="balloon,red balloon"/>
   <arg name="teddy_classes" default="teddy bear,stuffed animal,Winnie the Pooh plush"/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
-ultralytics>=8.4.45
+torch @ https://developer.nvidia.com/w/compute/redist/jp/v50/pytorch/torch-1.12.0a0+8a1a93a9.nv22.5-cp38-cp38-linux_aarch64.whl
+ultralytics==8.2.0
 lap>=0.5.13
+torchvision==0.13.0
 clip @ git+https://github.com/openai/CLIP.git

--- a/scripts/detect_events_node.py
+++ b/scripts/detect_events_node.py
@@ -64,6 +64,8 @@ FLEW_AWAY_DWELL_SECS = 2.0
 EDGE_MARGIN_RATIO = 0.10
 STABILITY_WINDOW_SECS = 3.0
 STABILITY_RADIUS_RATIO = 0.10
+INITIAL_RELATION_SECS = 1.0
+HELD_DIST_MARGIN_RATIO = 0.08
 STATE_COLORS = {
     "NO_BALLOON": (128, 128, 128),
     "APPROACHING": (0, 165, 255),
@@ -139,6 +141,10 @@ class BalloonEventDetector:
         self.last_balloon_xy = None
         self.last_t = None
         self.events = []
+        self.initial_dist_samples = []
+        self.initial_dist = None
+        self.initial_relation_done = False
+        self.held_dist_margin = HELD_DIST_MARGIN_RATIO * diag
 
     def update(self, frame_idx, t, balloon_box, teddy_box):
         dt = 0.0 if self.last_t is None else max(0.0, t - self.last_t)
@@ -170,7 +176,29 @@ class BalloonEventDetector:
             iou = iou_xyxy(balloon_box, teddy_box)
 
         balloon_visible = balloon_box is not None
-        balloon_close = (iou > HELD_IOU_THRESH) or (dist < self.held_dist_thresh)
+
+        # record distance between teddy and balloon first
+        if balloon_box is not None and teddy_box is not None and not self.initial_relation_done:
+            self.initial_dist_samples.append(dist)
+            if t >= INITIAL_RELATION_SECS and self.initial_dist_samples:
+                self.initial_dist = float(np.median(self.initial_dist_samples))
+                self.initial_relation_done = True
+                self.events.append(
+                    {
+                        "frame": frame_idx,
+                        "time_sec": round(t, 2),
+                        "event": "INITIAL_RELATION_SET",
+                        "note": f"initial_dist={self.initial_dist:.1f}, margin={self.held_dist_margin:.1f}",
+                    }
+                )
+
+        # judge if teddy is holding a balloon by comparing with initial distance
+        if self.initial_dist is not None:
+            balloon_close = dist <= self.initial_dist + self.held_dist_margin
+        else:
+            # if there is no initial distance, use threshold
+            balloon_close = (iou > HELD_IOU_THRESH) or (dist < self.held_dist_thresh)
+
         prev_state = self.state
 
         if balloon_visible:
@@ -259,12 +287,12 @@ class BalloonEventDetector:
                 self.state = "FLEW_AWAY"
                 self.held_total_secs = 0.0
         elif self.state == "FLEW_AWAY":
-            if balloon_visible and balloon_close:
-                self.state = "HELD"
-                self.held_secs = HOLD_SECS_FOR_HELD
-                self.held_total_secs = HOLD_SECS_FOR_HELD
-                self.received_emitted = False
-            elif balloon_visible:
+            # if balloon_visible and balloon_close:
+            #     self.state = "HELD"
+            #     self.held_secs = HOLD_SECS_FOR_HELD
+            #     self.held_total_secs = HOLD_SECS_FOR_HELD
+            #     self.received_emitted = False
+            if balloon_visible:
                 self.state = "APPROACHING"
                 self.held_secs = 0.0
 


### PR DESCRIPTION
I tried to use CUDA on a reComputer Mini J4012 for the balloon_detection branch, but encountered issues while installing PyTorch / TorchVision.

The problem seemed to be caused by accidentally installing non-Jetson NVIDIA packages such as libnvidia-compute-535, which conflicted with the JetPack / L4T environment on Jetson.

As a result, CUDA-related packages and Torch installation became inconsistent, and CUDA was not available from PyTorch.

@mqcmd196 helped fix the environment and restore proper CUDA support.